### PR TITLE
feat: add support for go

### DIFF
--- a/lua/trevj.lua
+++ b/lua/trevj.lua
@@ -18,6 +18,10 @@ end
 
 local settings = {
   containers = {
+    go = {
+      literal_value = make_default_opts(),
+      parameter_list = make_default_opts(),
+    },
     lua = {
       table_constructor = make_default_opts(),
       arguments = make_no_final_sep_opts(),


### PR DESCRIPTION
This only includes 2 types I could find to split on, so it's not exhaustive, but a lot of literal types in go use the same syntax, so it should cover a lot.

As a side note, when I tried testing this out in my config by just adding the go table, I kept getting filetype not supported errors. So I'm not sure adding in your own overrides works currently  but tbh I didn't check exhaustively as I don't have too much time to hand atm 