### PR TITLE
docs: add supported languages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use {
 ```
 
 ## Configuration
-Current default languages only include `lua`, `python` and `rust`. But you can add your own, of even better submit a PR for your favorite language.
+
 When configuring a language you should specify the treesitter node types that contains the child nodes which should be put on separate lines.
 For example for the default configuration for `lua` looks as follows:
 ```lua
@@ -47,6 +47,17 @@ where:
 * `final_separator`: if truthy adds this character after the final child node if not existing.
 * `final_end_line`: if there should be a final line before the and character of the container node.
 For existing languages you can override anything and defaults will be used for anything unspecified.
+
+## Supported Languages
+
+Currently only the following languages are supported by default:
+
+- lua
+- python
+- rust
+- go
+
+You can add your own, of even better submit a PR for your favorite language.
 
 ### Examples
 #### default


### PR DESCRIPTION
Noticed that my previous PR didn't update the docs and whilst adding in `go` it occurred to me that adding them all inline like that wouldn't scale, so I pulled the supported languages into a separate block. Let me know if this isn't quite what you had in mind and I can tweak it.