### PR TITLE
feat(javascript, typescript): add initial containers

### DIFF
--- a/lua/trevj.lua
+++ b/lua/trevj.lua
@@ -28,8 +28,41 @@ local make_c_containers = function()
   }
 end
 
+local make_javascript_typescript_containers = function()
+  local javascript = {
+    array = make_default_opts(),
+    object = make_default_opts(),
+    arguments = make_default_opts(),
+    namedimports = make_default_opts(),
+    object_pattern = make_default_opts(),
+    formal_parameters = make_default_opts(),
+  }
+
+  local jsx = {
+    jsx_element = make_no_final_sep_opts(),
+    jsx_opening_element = {
+      final_separator = false,
+      final_end_line = true,
+      skip = { identifier = true },
+    },
+  }
+  local typescript_only = {
+    type_parameters = make_default_opts(),
+    type_arguments = make_no_final_sep_opts(),
+  }
+
+  local typescript = vim.tbl_extend("error", javascript, typescript_only)
+
+  return {
+    javascript = javascript,
+    javascriptreact = vim.tbl_extend("error", javascript, jsx),
+    typescript = typescript,
+    typescriptreact = vim.tbl_extend("error", typescript, jsx),
+  }
+end
+
 local settings = {
-  containers = {
+  containers = vim.tbl_extend("error", {
     c = make_c_containers(),
     cpp = make_c_containers(),
     go = {
@@ -75,7 +108,7 @@ local settings = {
       field_declaration_list = make_default_opts(),
       array_expression = make_default_opts(),
     },
-  },
+  }, make_javascript_typescript_containers()),
 }
 
 local warn = function(msg, ...)


### PR DESCRIPTION
First of all, this plugin is awesome!

I've decided to add initial containers for `javascript` and `typescript` filetypes, since those are the main filetypes I work with. I also included `javascriptreact` and `typescriptreact` (their JSX counterparts).

This allows convenient use of trevJ in JavaScript and TypeScript code.

## Verification

<details>
<summary>Example `typescriptreact` code for verification.

It includes most of the patterns added by this PR.
</summary>

```tsx
import { Footer } from "./Footer";
import { Header } from "./Header";

type MyType<Arg, Arg2, Arg3> = Arg extends Partial<PropsWithChildren<any>>
  ? never
  : true;

styled<Abc>({ width: 100 });

const obj = { a: 1, b: 2, c: 3 };
const arr = [1, 2, 3, 4];

export const Layout = ({ children, a, b }: PropsWithChildren<unknown>, a, b, c) => (
  <LayoutContainer>
    <Header />
    <MainContainer someProp anotherProp>
      {children}
    </MainContainer>
    <Footer />
  </LayoutContainer>
);

const MainContainer = styled("main")({ flexGrow: 1 });
```

</details>

https://user-images.githubusercontent.com/889383/163326124-703cffdd-25e8-4e19-92af-067c734a85bd.mp4



