### PR TITLE
feat(typescript): support `object_type` node

### DIFF
--- a/lua/trevj.lua
+++ b/lua/trevj.lua
@@ -51,6 +51,7 @@ local make_javascript_typescript_containers = function()
   local typescript_only = {
     type_parameters = make_default_opts(),
     type_arguments = make_no_final_sep_opts(),
+    object_type = vim.tbl_extend("force", make_default_opts(), { final_separator = ";" }),
   }
 
   local typescript = vim.tbl_extend("error", javascript, typescript_only)


### PR DESCRIPTION
Allows unjoining objects in type definitions.

# Example

```ts
type SomeType = { variant: "finished"; result: QueryResult; executedAt: Date };
```



Before:

![image](https://user-images.githubusercontent.com/889383/189307145-e8a796cf-2a6f-44be-b737-f89e30f513c2.png)

After:

![image](https://user-images.githubusercontent.com/889383/189307263-53bb191e-fd97-4f19-94bf-eaac29660270.png)
