### PR TITLE
fix(): handle cases where brackets are not children of container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # nvim-trevJ.lua
 
-:warning: *This plugin is in an early stage and docs is a bit sparse. Feel free to try it out though and let me know if you have any problems/suggestions.*
-
 Nvim-plugin for doing the opposite of join-line (J) of arguments, powered by treesitter.
 The intention of the plugin is the same as [`revJ`](https://github.com/AckslD/nvim-revJ.lua).
 However `trevJ` uses treesitter to figure out the formatting and in general does everything much more efficient and better, while not polluting registers, last visual selection etc.

--- a/lua/trevj.lua
+++ b/lua/trevj.lua
@@ -128,6 +128,9 @@ local settings = {
       parameter_list = make_default_opts(),
       parameter_call_list = make_default_opts(),
     },
+    r = {
+      arguments = make_no_final_sep_opts(),
+    },
   }, make_javascript_typescript_containers()),
 }
 
@@ -226,7 +229,13 @@ M.format_at_cursor = function()
         new_lines[#new_lines] = new_lines[#new_lines] .. table.remove(lines, 1)
         vim.list_extend(new_lines, lines)
       elseif child:named() then
+        if #new_lines == 0 then
+          new_lines = { "" }
+        end
         vim.list_extend(new_lines, indent_lines(lines, indent + shiftwidth))
+        if opts.final_end_line and i == #children then
+          vim.list_extend(new_lines, { "" })
+        end
       else
         if opts.final_end_line and i == #children then
           vim.list_extend(new_lines, indent_lines(lines, indent))


### PR DESCRIPTION
closes #36 

The issue with languages such as `r` is that the opening and closing brackets are not node-children of the container node. For example in `r`:
```r
f(a, b)
```
has the tree:
```
(call) ; [1:1 - 7]
 function: (identifier) ; [1:1 - 1]
 "(" ; [1:2 - 2]
 arguments: (arguments) ; [1:3 - 6]
  (identifier) ; [1:3 - 3]
  "," ; [1:4 - 4]
  (identifier) ; [1:6 - 6]
 ")" ; [1:7 - 7]
"\n" ; [1:8 - 2:0]
```
whereas eg `python` (and all other languages I've seen) have something like:
```python
def f(a, b):
    pass
```
with
```
(function_definition) ; [1:1 - 2:8]
 "def" ; [1:1 - 3]
 name: (identifier) ; [1:5 - 5]
 parameters: (parameters) ; [1:6 - 11]
  "(" ; [1:6 - 6]
  (identifier) ; [1:7 - 7]
  "," ; [1:8 - 8]
  (identifier) ; [1:10 - 10]
  ")" ; [1:11 - 11]
 ":" ; [1:12 - 12]
 body: (block) ; [2:5 - 8]
  (pass_statement) ; [2:5 - 8]
   "pass" ; [2:5 - 8]
```
ie the opening and closing brackets are part of `parameters` whereas in `r` it is part of `function`.
